### PR TITLE
Fix a bug in parsing arguments with equal sign: --param=value

### DIFF
--- a/qcloudcli/handleParameter.py
+++ b/qcloudcli/handleParameter.py
@@ -46,6 +46,7 @@ class handleParameter():
                         b = self.args[current].strip().split('=', 2)[1]
                         self.args[current] = a
                         self.args.insert(current + 1, b)
+                        argslen = len(self.args)
                     key = self.args[current].strip()
                     values = list()
                     length = len(self.args)


### PR DESCRIPTION
qcloudcli fails to update the number of cli arguments when splitting arguments with equal sign,
such as --param=value. The result is that the trailing arguments are ignored.