### PR TITLE
add system wide condig path

### DIFF
--- a/qcloudcli/configure.py
+++ b/qcloudcli/configure.py
@@ -27,9 +27,24 @@ class QcloudConfig(object):
         self.home = ".qcloudcli"
         self.configure = "configure"
         self.credentials = "credentials"
-        self.qcloudConfigurePath = os.path.join(self.findConfigureFilePath(),
-                                                self.home)
         self.parser = handleParameter.handleParameter()
+
+    def showQcloudConfigurePath(self):
+        configurePathName = ".qcloudcli"
+        sysHomePath = ''
+        if 'Windows' in platform.system():
+            sysHomePath = os.environ['HOMEPATH']
+        else:
+            sysHomePath = os.environ['HOME']
+            pass
+        qcloudConfigurePath = os.path.join(sysHomePath, configurePathName)
+        if os.path.isdir(qcloudConfigurePath):
+            return qcloudConfigurePath
+        if 'Windows' not in platform.system():
+            systemWideConfigurePath = '/etc/qcloudcli'
+            if os.path.isdir(systemWideConfigurePath):
+                return systemWideConfigurePath
+        return qcloudConfigurePath
 
     def getConfig(self, profilename=None):
         if profilename is None:
@@ -63,10 +78,10 @@ class QcloudConfig(object):
                     j = j+1
 
     def getConfigFileName(self):
-        return os.path.join(self.qcloudConfigurePath, self.configure)
+        return os.path.join(self.showQcloudConfigurePath(), self.configure)
 
     def getCredsFileName(self):
-        return os.path.join(self.qcloudConfigurePath, self.credentials)
+        return os.path.join(self.showQcloudConfigurePath(), self.credentials)
 
     def findConfigureFilePath(self):
         homePath = ""

--- a/qcloudcli/handleCmd.py
+++ b/qcloudcli/handleCmd.py
@@ -74,21 +74,7 @@ class handleCmd(object):
               "know the module corresponding actions." % (self.red, self.end))
 
     def showQcloudConfigurePath(self):
-        configurePathName = ".qcloudcli"
-        sysHomePath = ''
-        if 'Windows' in platform.system():
-            sysHomePath = os.environ['HOMEPATH']
-        else:
-            sysHomePath = os.environ['HOME']
-            pass
-        qcloudConfigurePath = os.path.join(sysHomePath, configurePathName)
-        if os.path.isdir(qcloudConfigurePath):
-            return qcloudConfigurePath
-        if 'Windows' not in platform.system():
-            systemWideConfigurePath = '/etc/qcloudcli'
-            if os.path.isdir(systemWideConfigurePath):
-                return systemWideConfigurePath
-        return qcloudConfigurePath
+        return self.globalConfigure.showQcloudConfigurePath()
 
     def getAllmodules(self):
         site_packages_path = get_python_lib()

--- a/qcloudcli/handleCmd.py
+++ b/qcloudcli/handleCmd.py
@@ -82,6 +82,12 @@ class handleCmd(object):
             sysHomePath = os.environ['HOME']
             pass
         qcloudConfigurePath = os.path.join(sysHomePath, configurePathName)
+        if os.path.isdir(qcloudConfigurePath):
+            return qcloudConfigurePath
+        if 'Windows' not in platform.system():
+            systemWideConfigurePath = '/etc/qcloudcli'
+            if os.path.isdir(systemWideConfigurePath):
+                return systemWideConfigurePath
         return qcloudConfigurePath
 
     def getAllmodules(self):


### PR DESCRIPTION
Use `/etc/qcloudcli` as config path if it exists and `$HOME/.qcloudcli` not exists.

支持全局配置目录，对原有 HOME 下配置目录的逻辑没有影响。